### PR TITLE
Полное покрытие тестами - без необходимости их писать и переписывать

### DIFF
--- a/src/Danilson/Definition/AsIs.php
+++ b/src/Danilson/Definition/AsIs.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Definition;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Definition\SpecificationInterface;
+
+class AsIs implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return true;
+    }
+}

--- a/src/Danilson/Definition/Dependency/AsIs.php
+++ b/src/Danilson/Definition/Dependency/AsIs.php
@@ -1,0 +1,13 @@
+<?php
+namespace Zp\PHPWire\Danilson\Definition\Dependency;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Definition\Dependency\SpecificationInterface;
+
+class AsIs implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        // @todo
+        return true;
+    }
+}

--- a/src/Danilson/Definition/Dependency/WithNotExists.php
+++ b/src/Danilson/Definition/Dependency/WithNotExists.php
@@ -1,0 +1,13 @@
+<?php
+namespace Zp\PHPWire\Danilson\Definition\Dependency;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Definition\Dependency\SpecificationInterface;
+
+class WithNotExists implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        // @todo
+        return true;
+    }
+}

--- a/src/Danilson/Definition/Dependency/WithNotImplements.php
+++ b/src/Danilson/Definition/Dependency/WithNotImplements.php
@@ -1,0 +1,13 @@
+<?php
+namespace Zp\PHPWire\Danilson\Definition\Dependency;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Definition\Dependency\SpecificationInterface;
+
+class WithNotImplements implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        // @todo
+        return true;
+    }
+}

--- a/src/Danilson/Definition/WithDependency.php
+++ b/src/Danilson/Definition/WithDependency.php
@@ -1,0 +1,13 @@
+<?php
+namespace Zp\PHPWire\Danilson\Definition;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Definition\SpecificationInterface;
+
+class WithDependency implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        // @todo
+        return true;
+    }
+}

--- a/src/Danilson/Interfaces/Container/Definition/Dependency/SpecificationInterface.php
+++ b/src/Danilson/Interfaces/Container/Definition/Dependency/SpecificationInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Zp\PHPWire\Danilson\Interfaces\Container\Definition\Dependency;
+
+
+interface SpecificationInterface extends \Zp\PHPWire\Danilson\Interfaces\SpecificationInterface
+{}

--- a/src/Danilson/Interfaces/Container/Definition/SpecificationInterface.php
+++ b/src/Danilson/Interfaces/Container/Definition/SpecificationInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Zp\PHPWire\Danilson\Interfaces\Container\Definition;
+
+
+interface SpecificationInterface extends \Zp\PHPWire\Danilson\Interfaces\SpecificationInterface
+{}

--- a/src/Danilson/Interfaces/Container/Key/SpecificationInterface.php
+++ b/src/Danilson/Interfaces/Container/Key/SpecificationInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Zp\PHPWire\Danilson\Interfaces\Container\Key;
+
+
+interface SpecificationInterface extends \Zp\PHPWire\Danilson\Interfaces\SpecificationInterface
+{}

--- a/src/Danilson/Interfaces/Container/Value/ContainerValueSpecificationInterface.php
+++ b/src/Danilson/Interfaces/Container/Value/ContainerValueSpecificationInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Zp\PHPWire\Danilson\Interfaces\Container\Value;
+
+
+interface SpecificationInterface extends \Zp\PHPWire\Danilson\Interfaces\SpecificationInterface
+{}

--- a/src/Danilson/Interfaces/SpecificationInterface.php
+++ b/src/Danilson/Interfaces/SpecificationInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace Zp\PHPWire\Danilson\Interfaces;
+
+
+interface SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool;
+}

--- a/src/Danilson/Key/AsClass.php
+++ b/src/Danilson/Key/AsClass.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Key;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Key\SpecificationInterface;
+
+class AsClass implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return class_exists($value);
+    }
+}

--- a/src/Danilson/Key/AsInterface.php
+++ b/src/Danilson/Key/AsInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Key;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Key\SpecificationInterface;
+
+class AsInterface implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return interface_exists($value);
+    }
+}

--- a/src/Danilson/Key/AsStringAlias.php
+++ b/src/Danilson/Key/AsStringAlias.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Key;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Key\SpecificationInterface;
+
+class AsStringAlias implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return is_string($value) && !(new AsClass())->isSatisfiedBy($value);
+    }
+}

--- a/src/Danilson/Value/AsArgs.php
+++ b/src/Danilson/Value/AsArgs.php
@@ -1,0 +1,13 @@
+<?php
+namespace Zp\PHPWire\Danilson\Value;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Value\SpecificationInterface;
+
+class AsArgs implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        // @todo
+        return true;
+    }
+}

--- a/src/Danilson/Value/AsEmpty.php
+++ b/src/Danilson/Value/AsEmpty.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Value;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Value\SpecificationInterface;
+
+class AsEmpty implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return empty($value);
+    }
+}

--- a/src/Danilson/Value/ClassName/AsIs.php
+++ b/src/Danilson/Value/ClassName/AsIs.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Value\ClassName;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Value\SpecificationInterface;
+
+class AsIs implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return isset($value['class']) && class_exists($value['class']);
+    }
+}

--- a/src/Danilson/Value/ClassName/WithAbsract.php
+++ b/src/Danilson/Value/ClassName/WithAbsract.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: patchranger
+ * Date: 13.08.18
+ * Time: 22:38
+ */

--- a/src/Danilson/Value/ClassName/WithExtendedBy.php
+++ b/src/Danilson/Value/ClassName/WithExtendedBy.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: patchranger
+ * Date: 13.08.18
+ * Time: 22:38
+ */

--- a/src/Danilson/Value/ClassName/WithExtends.php
+++ b/src/Danilson/Value/ClassName/WithExtends.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: patchranger
+ * Date: 13.08.18
+ * Time: 22:38
+ */

--- a/src/Danilson/Value/InterfaceName/AsIs.php
+++ b/src/Danilson/Value/InterfaceName/AsIs.php
@@ -1,0 +1,12 @@
+<?php
+namespace Zp\PHPWire\Danilson\Value\InterfaceName;
+
+use Zp\PHPWire\Danilson\Interfaces\Container\Value\SpecificationInterface;
+
+class AsIs implements SpecificationInterface
+{
+    public function isSatisfiedBy($value): bool
+    {
+        return isset($value['class']) && interface_exists($value['class']);
+    }
+}

--- a/tests/src/Container/ConstructorTest.php
+++ b/tests/src/Container/ConstructorTest.php
@@ -4,6 +4,7 @@ namespace Zp\PHPWire\Tests\Container;
 
 use PHPUnit\Framework\TestCase;
 use Zp\PHPWire\Container;
+use Zp\PHPWire\Danilson;
 use Zp\PHPWire\Tests\Fixtures\ClassDependency;
 use Zp\PHPWire\Tests\Fixtures\InterfaceDependency;
 use Zp\PHPWire\Tests\Fixtures\ScalarDependency;
@@ -75,5 +76,142 @@ class ConstructorTest extends TestCase
         // assert
         $this->assertInstanceOf(InterfaceDependency::class, $entry);
         $this->assertInstanceOf(Foo::class, $entry->getFoo());
+    }
+
+    /**
+     * @param array $spec
+     * @dataProvider everythingDataProvider
+     */
+    public function testEverything(array $spec): void
+    {
+        $container = new Container($this->getFixtureDefinitionsBySpec($spec));
+        $this->assertInstanceOf(Container::class, $container);
+        $this->assertContractBySpec($spec, $container);
+    }
+
+    public function everythingDataProvider(): array
+    {
+        // @todo Find specs by implemented interfaces.
+        $definitionSpecs = $this->cartesian([
+            'as' => [
+                Danilson\Definition\AsIs::class,
+            ],
+            'with' => [
+                null,
+                Danilson\Definition\WithDependency::class,
+
+            ],
+        ]);
+        $dependencySpecs = $this->cartesian([
+            'as' => [
+                Danilson\Definition\Dependency\AsIs::class,
+            ],
+            'with' => [
+                null,
+                Danilson\Definition\Dependency\WithNotExists::class,
+
+            ],
+        ]);
+        $keySpecs = [Danilson\Key\AsClass::class, Danilson\Key\AsInterface::class, Danilson\Key\AsStringAlias::class];
+        $valueSpecs = [Danilson\Value\AsEmpty::class, Danilson\Value\ClassName\AsIs::class];
+
+        $combinations = $this->cartesian([
+            'definition' => $definitionSpecs,
+            'key' => $keySpecs,
+            'value' => $valueSpecs,
+            'dependency' => $dependencySpecs,
+            'dependencyKey' => $keySpecs,
+            'dependencyValue' => $valueSpecs,
+        ]);
+        $combinations = array_unique(array_map(function ($item) {
+            if ($item['definition']['with'] === null) {
+                unset($item['dependency']);
+                unset($item['dependencyKey']);
+                unset($item['dependencyValue']);
+            }
+            return json_encode($item);
+        }, $combinations));
+        $specs = array_map(function ($item) { return ['spec' => json_decode($item, true)]; }, $combinations);
+        return $specs;
+    }
+
+    private function getFixtureDefinitionsBySpec($spec): array
+    {
+        $result = [];
+        $result[$this->getFixtureKeyBySpec($spec['key'])] = $this->getFixtureValueBySpec($spec['value'], $spec);
+        if ($spec['dependency'] ?? false) {
+            $result[$this->getFixtureKeyBySpec($spec['dependencyKey'])] = $this->getFixtureValueBySpec($spec['dependencyValue'], $spec);
+        }
+        return $result;
+    }
+
+    private function getFixtureKeyBySpec($spec): string
+    {
+        switch ($spec) {
+            case Danilson\Key\AsClass::class:
+                return Foo::class;
+            case Danilson\Key\AsInterface::class:
+                return FooInterface::class;
+            case Danilson\Key\AsStringAlias::class:
+                return 'foo';
+            default:
+                throw new \InvalidArgumentException($spec);
+        }
+    }
+
+    private function getFixtureValueBySpec(string $specValue, array $spec): array
+    {
+        switch (true) {
+            case ($spec['dependency']['with'] ?? null) == Danilson\Definition\Dependency\WithNotExists::class:
+                return ['class' => 'bar'];
+            case Danilson\Value\ClassName\AsIs::class == $specValue:
+                return ['class' => Foo::class];
+            case Danilson\Value\AsEmpty::class == $specValue:
+                return [];
+            // @todo Add WithAbsract for AsClass.
+            // @todo Add WithExtends for AsClass.
+            // @todo Add WithExtendedBy for AsClass.
+            // @todo Add AsInterface.
+            // @todo Add WithNotImplements for AsInterface.
+            default:
+                throw new \InvalidArgumentException($spec);
+        }
+    }
+
+    // @link https://stackoverflow.com/a/15973172
+    private function cartesian($input) {
+        $result = array(array());
+
+        foreach ($input as $key => $values) {
+            $append = array();
+
+            foreach ($result as $product) {
+                foreach ($values as $item) {
+                    $product[$key] = $item;
+                    $append[] = $product;
+                }
+            }
+
+            $result = $append;
+        }
+
+        return $result;
+    }
+
+    private function assertContractBySpec($spec, Container $container): void
+    {
+        // @todo Refactor with mock and shouldThrowException.
+        if (
+            ($spec['dependency']['with'] ?? null) === Danilson\Definition\Dependency\WithNotExists::class
+            &&
+            $spec['dependencyValue'] !== Danilson\Value\AsEmpty::class
+
+        ) {
+            throw new \LogicException(print_r([
+                'error' => 'Should throw InvalidArgumentException',
+                'spec' => $spec,
+                'container' => $container,
+            ], true));
+        }
     }
 }


### PR DESCRIPTION
### TL;DR
Я сделал штуку, которая обеспечивает полнейшее покрытие тестами без необходимости создавать новые и исправлять старые тесты. При этом она автоматически вскрывает все теоретически возможные сценарии использования - тем самым, не оставляя багам шанса.

### Дисклеймер
1) Это ни в коем случае не готовое решение, к мёрджу не пригодно - это лишь прототип, "proof-of-concept", "не ключ, а рисунок ключа").
2) Предлагаемое решение не ограничивается рамками одного этого репозитория - это подход, который может быть применён где угодно.

### Что это?
Это реализация (крайне грубая, сделанная за выходные "на коленке" - но всё же) концепции, объединяющей подходы декларативного программирования и ТРИЗ.

### Зачем?
Для достижения Идеального Конечного Результата (ИКР) тестирования: программа протестирована, а системы, выполняющей её тестирование, - нет.
Для этого необходимо, чтобы тесты возникали сами собой (без дополнительных усилий) в процессе разработки программы.
Иными словами, для автоматизации автоматизации тестирования)

### Как (в теории)?
Разбить программу на 3 функциональные составляющие:
1) Спецификации входных данных. Комбинируя все возможные спецификации всех возможных параметров получим все возможные сценарии использования.
2) Логическая часть программы: на входе сценарий использования, на выходе - стратегия.
3) Стратегии.

Тесты будут появляться в результате декартова произведения известных спецификаций. То есть, переборщик создан заранее (его прототип - уже в пулл-реквесте), спецификации появляются и изменяются в процессе разработки программы - а полнота и качество тестового покрытия обеспечивается перебором декартового произведения всех возможных спецификаций, влияющих на работу программы.
По умолчанию этот перебор - это смоук-тест: пробует на любых сценариях использования запустить тестируемый кусок программы, если завелось без ошибок, то норм. Но можно переопределять своими ожиданиями - я так и сделал, добавив ассерт на необходимость вылета исключения (см. пример ниже). По-хорошему, на выходе должны быть классы стратегий - но пока (для простоты) так.
Написание программы станет тождественно равно созданию сценариев использования - путём добавления новых спецификаций.
Таким образом, программа будет протестирована - а системы, выполняющей её тестирование как бы нет: она не требует усилий на поддержание и расширение.

### Как (на практике)?
На данный момент:
- Спецификации и стратегии не являются частью исполняемой программы. Изменён только тест - для минимальной демонстрации и ииллюстрации замысла.
- Переборщик пока не расширяется: перебирает только то, что ему явно сказано перебирать.

### Пример применения?
Если мыслить категориями спецификаций входных параметров, то сразу становится понятно, как много сценариев использования существующий код игнорирует.
Я могу быть не прав, но мне кажется, я нашёл баг в существующем коде.
Запустив тест, получаем такую ошибку:
```
$ vendor/bin/phpunit --stop-on-failure --filter testEverything tests/src/Container/ConstructorTest.php
> PHPUnit 6.5.11 by Sebastian Bergmann and contributors.

.............E

Time: 109 ms, Memory: 4.00MB

There was 1 error:

1) Zp\PHPWire\Tests\Container\ConstructorTest::testEverything with data set #13 (array(array('Zp\PHPWire\Danilson\Definition\AsIs', 'Zp\PHPWire\Danilson\Definitio...ndency'), 'Zp\PHPWire\Danilson\Key\AsClass', 'Zp\PHPWire\Danilson\Value\AsEmpty', array('Zp\PHPWire\Danilson\Definitio...y\AsIs', 'Zp\PHPWire\Danilson\Definitio...Exists'), 'Zp\PHPWire\Danilson\Key\AsClass', 'Zp\PHPWire\Danilson\Value\AsClass'))
LogicException: Array
(
    [error] => Should throw InvalidArgumentException
    [spec] => Array
        (
            [definition] => Array
                (
                    [as] => Zp\PHPWire\Danilson\Definition\AsIs
                    [with] => Zp\PHPWire\Danilson\Definition\WithDependency
                )

            [key] => Zp\PHPWire\Danilson\Key\AsClass
            [value] => Zp\PHPWire\Danilson\Value\AsEmpty
            [dependency] => Array
                (
                    [as] => Zp\PHPWire\Danilson\Definition\Dependency\AsIs
                    [with] => Zp\PHPWire\Danilson\Definition\Dependency\WithNotExists
                )

            [dependencyKey] => Zp\PHPWire\Danilson\Key\AsClass
            [dependencyValue] => Zp\PHPWire\Danilson\Value\AsClass
        )

    [container] => Zp\PHPWire\Container Object
        (
            [singletons:Zp\PHPWire\Container:private] => Array
                (
                    [container] => Zp\PHPWire\Container Object
 *RECURSION*
                    [Zp\PHPWire\Container] => Zp\PHPWire\Container Object
 *RECURSION*
                    [Psr\Container\ContainerInterface] => Zp\PHPWire\Container Object
 *RECURSION*
                )

            [definitions:Zp\PHPWire\Container:private] => Array
                (
                    [Zp\PHPWire\Tests\Fixtures\Foo] => Array
                        (
                            [class] => stdClass
                        )

                )

            [proxyFactory:Zp\PHPWire\Container:private] => 
            [compiledContainerFile:Zp\PHPWire\Container:private] => 
            [compiledContainer:Zp\PHPWire\Container:private] => 
        )

)


/phpwire/tests/src/Container/ConstructorTest.php:204
/phpwire/tests/src/Container/ConstructorTest.php:89

ERRORS!
Tests: 14, Assertions: 14, Errors: 1.
```
Как видно, исключение содержит спеку сценария использования, что даёт представление о "человекопонятном смысле" происходящего в программе: зависимость объявлена со ссылкой на несуществующий элемент контейнера - а контейнер не провалидировал это, дал в себя сохранить.
Не то, что бы этот баг очень критичен, это просто неучтённый негативный сценарий, - я лишь хочу продемонстрировать, что благодаря смене подхода неучтённые сценарии перестают быть неучтёнными, неявное становится явным, багам не скрыться.

### В чём профит?
1) Автоматизация автоматизации тестирования) : "Спиннер крутится, тесты пишутся") Не тратим время на тесты.
2) Модульность и переиспользование: Благодаря разделению на спецификации, логическую часть и стратегии, мы можем одни и те же спецификации и стратегии использовать множество раз - тем самым сокращая объём поддерживаемого кода.
3) Декларативность: Подход обеспечивает понятность логики кода, превращая программу в исполняемую документацию самой себя.

Что думаете? Дайте знать, насколько адекватно то, что я натворил)